### PR TITLE
Update dotenv loading and document env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ DB_HOST=localhost
 DB_PORT=5432
 ```
 
+Optionally, set `ENV_PATH` to point to a custom environment file before running
+any scripts. If not set, `.env` in the project root is used.
+
 ### Starting the Servers
 
 1. Start the HTTP server: `python -m http.server 8080`

--- a/check_db_schema.py
+++ b/check_db_schema.py
@@ -8,8 +8,9 @@ from colorama import init, Fore, Style
 # Initialize colorama for colored output
 init()
 
-# Load environment variables from .env file
-load_dotenv('ehr-project/backend/.env')
+# Load environment variables from .env file (configurable via ENV_PATH)
+env_path = os.getenv('ENV_PATH', '.env')
+load_dotenv(env_path)
 
 # Database connection parameters
 DB_CONFIG = {

--- a/create_test_user.py
+++ b/create_test_user.py
@@ -5,8 +5,9 @@ import hashlib
 from datetime import datetime
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv('ehr-project/backend/.env')
+# Load environment variables from .env file (configurable via ENV_PATH)
+env_path = os.getenv('ENV_PATH', '.env')
+load_dotenv(env_path)
 
 # Database connection parameters
 DB_CONFIG = {

--- a/generate_realistic_data.py
+++ b/generate_realistic_data.py
@@ -13,8 +13,9 @@ from colorama import init, Fore, Style
 # Initialize colorama for colored output
 init()
 
-# Load environment variables from .env file
-load_dotenv('ehr-project/backend/.env')
+# Load environment variables from .env file (configurable via ENV_PATH)
+env_path = os.getenv('ENV_PATH', '.env')
+load_dotenv(env_path)
 
 # Database connection parameters
 DB_CONFIG = {

--- a/login_api.py
+++ b/login_api.py
@@ -9,8 +9,9 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv('ehr-project/backend/.env')
+# Load environment variables from .env file (configurable via ENV_PATH)
+env_path = os.getenv('ENV_PATH', '.env')
+load_dotenv(env_path)
 
 # Database connection parameters
 DB_CONFIG = {

--- a/patient_api.py
+++ b/patient_api.py
@@ -7,8 +7,9 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv('ehr-project/backend/.env')
+# Load environment variables from .env file (configurable via ENV_PATH)
+env_path = os.getenv('ENV_PATH', '.env')
+load_dotenv(env_path)
 
 # Database connection parameters
 DB_CONFIG = {

--- a/setup_db_tables.py
+++ b/setup_db_tables.py
@@ -5,8 +5,9 @@ from psycopg2 import sql
 from datetime import datetime
 from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv('ehr-project/backend/.env')
+# Load environment variables from .env file (configurable via ENV_PATH)
+env_path = os.getenv('ENV_PATH', '.env')
+load_dotenv(env_path)
 
 # Database connection parameters
 DB_CONFIG = {


### PR DESCRIPTION
## Summary
- use `ENV_PATH` to configure dotenv path across all scripts
- document optional `ENV_PATH` variable in README

## Testing
- `python -m py_compile login_api.py patient_api.py create_test_user.py check_db_schema.py generate_realistic_data.py setup_db_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_684a4372f3e483269ed9590aae93368b