### PR TITLE
Align login history table and password column

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ The system uses PostgreSQL with the following key tables:
 2. Run the database setup script: `python setup_db_tables.py`
 3. Create a test user: `python create_test_user.py`
 
+If you created the database before this version, drop the old `user_logins` table and recreate the tables to use `login_history` and the `hashed_password` column:
+```bash
+psql -d ehr_db -c "DROP TABLE IF EXISTS user_logins";
+python setup_db_tables.py
+```
+
 ### Environment Configuration
 
 Create a `.env` file in the project root with the following variables:

--- a/login_api.py
+++ b/login_api.py
@@ -78,12 +78,12 @@ def login():
             return jsonify({"success": False, "message": "Invalid username or password"}), 401
         
         user_id, db_username, hashed_password = user_data
-        
+
         # Hash the provided password
-        password_hash = hash_password(password)
-        
+        hashed_input = hash_password(password)
+
         # Check if password hashes match
-        if password_hash != hashed_password:
+        if hashed_input != hashed_password:
             # Record failed login attempt
             try:
                 cursor.execute(

--- a/setup_db_tables.py
+++ b/setup_db_tables.py
@@ -67,7 +67,7 @@ def create_tables(conn):
             username VARCHAR(50) UNIQUE NOT NULL,
             email VARCHAR(100) UNIQUE NOT NULL,
             full_name VARCHAR(100) NOT NULL,
-            password_hash VARCHAR(255) NOT NULL,
+            hashed_password VARCHAR(255) NOT NULL,
             role VARCHAR(20) NOT NULL DEFAULT 'user',
             is_active BOOLEAN NOT NULL DEFAULT TRUE,
             created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -75,11 +75,11 @@ def create_tables(conn):
         )
         """,
         """
-        CREATE TABLE IF NOT EXISTS user_logins (
+        CREATE TABLE IF NOT EXISTS login_history (
             id SERIAL PRIMARY KEY,
             user_id INTEGER REFERENCES users(id),
-            login_time TIMESTAMP NOT NULL,
-            ip_address VARCHAR(45) NOT NULL,
+            timestamp TIMESTAMP NOT NULL,
+            "ipAddress" VARCHAR(45) NOT NULL,
             success BOOLEAN NOT NULL,
             user_agent VARCHAR(255)
         )
@@ -163,7 +163,7 @@ def insert_sample_data(conn):
     """Insert sample data into the EHR system"""
     commands = [
         """
-        INSERT INTO users (username, email, full_name, password_hash, role)
+        INSERT INTO users (username, email, full_name, hashed_password, role)
         VALUES 
             ('admin', 'admin@example.com', 'Administrator', 
              '8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918', 'admin'),


### PR DESCRIPTION
## Summary
- use a single `login_history` table name everywhere
- use `hashed_password` field for users
- update setup and sample data accordingly
- document dropping the old table in README
- clean up variable naming in `login_api.py`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684a436ab9488326852f3de85fefa019