### PR TITLE
Add appointments API and integrate with frontend

### DIFF
--- a/appointments.html
+++ b/appointments.html
@@ -424,47 +424,55 @@
         }
         
         function loadAppointments() {
-            // Show loading spinner
             const spinner = document.getElementById('loadingSpinner');
             spinner.style.display = 'block';
-            
-            // For demo purposes, we're using generated data
-            // In a real app, this would fetch from an API
-            setTimeout(() => {
-                spinner.style.display = 'none';
-                
-                // Generate appointments based on filter
-                let appointments = generateSampleAppointments();
-                
+
+            fetch('http://localhost:8003/api/appointments')
+                .then(response => response.json())
+                .then(data => {
+                    spinner.style.display = 'none';
+
+                    if (data.success) {
+                        let appointments = data.appointments;
+
                 // Filter appointments based on current filter
                 const today = new Date();
                 today.setHours(0, 0, 0, 0);
-                
+
                 switch (currentFilter) {
                     case 'today':
                         appointments = appointments.filter(apt => {
-                            const aptDate = new Date(apt.date);
+                            const aptDate = new Date(apt.appointment_time);
                             aptDate.setHours(0, 0, 0, 0);
                             return aptDate.getTime() === today.getTime();
                         });
                         break;
                     case 'upcoming':
-                        appointments = appointments.filter(apt => new Date(apt.date) > today);
+                        appointments = appointments.filter(apt => new Date(apt.appointment_time) > today);
                         break;
                     case 'past':
-                        appointments = appointments.filter(apt => new Date(apt.date) < today);
+                        appointments = appointments.filter(apt => new Date(apt.appointment_time) < today);
                         break;
                     case 'custom':
                         appointments = appointments.filter(apt => {
-                            const aptDate = new Date(apt.date);
+                            const aptDate = new Date(apt.appointment_time);
                             aptDate.setHours(0, 0, 0, 0);
                             return aptDate.getTime() === selectedDate.getTime();
                         });
                         break;
                 }
-                
+
                 renderAppointments(appointments);
-            }, 800); // Simulate network delay
+                    } else {
+                        console.error('Error loading appointments:', data.message);
+                        renderAppointments([]);
+                    }
+                })
+                .catch(error => {
+                    console.error('API error:', error);
+                    spinner.style.display = 'none';
+                    renderAppointments([]);
+                });
         }
         
         function renderAppointments(appointments) {
@@ -477,7 +485,7 @@
             }
             
             // Sort appointments by date (newest first)
-            appointments.sort((a, b) => new Date(b.date) - new Date(a.date));
+            appointments.sort((a, b) => new Date(b.appointment_time) - new Date(a.appointment_time));
             
             appointments.forEach(appointment => {
                 const row = document.createElement('tr');
@@ -500,7 +508,7 @@
                 
                 row.innerHTML = `
                     <td>${appointment.id}</td>
-                    <td>${formatDateTime(appointment.date)}</td>
+                    <td>${formatDateTime(appointment.appointment_time)}</td>
                     <td>${appointment.patient}</td>
                     <td>${appointment.provider}</td>
                     <td>${appointment.reason}</td>
@@ -517,105 +525,6 @@
             });
         }
         
-        function generateSampleAppointments() {
-            // This is only used for demo purposes
-            // In a real application, this data would come from an API
-            const today = new Date();
-            const tomorrow = new Date(today);
-            tomorrow.setDate(tomorrow.getDate() + 1);
-            
-            const yesterday = new Date(today);
-            yesterday.setDate(yesterday.getDate() - 1);
-            
-            const nextWeek = new Date(today);
-            nextWeek.setDate(nextWeek.getDate() + 7);
-            
-            const lastWeek = new Date(today);
-            lastWeek.setDate(lastWeek.getDate() - 7);
-            
-            return [
-                {
-                    id: 1,
-                    date: today.toISOString(),
-                    patient: 'Calderon, Stacey',
-                    provider: 'Dr. Smith',
-                    reason: 'Annual Physical',
-                    status: 'Scheduled'
-                },
-                {
-                    id: 2,
-                    date: today.toISOString(),
-                    patient: 'Williams, Ian',
-                    provider: 'Dr. Johnson',
-                    reason: 'Follow-up',
-                    status: 'Scheduled'
-                },
-                {
-                    id: 3,
-                    date: tomorrow.toISOString(),
-                    patient: 'Castaneda, Michael',
-                    provider: 'Dr. Smith',
-                    reason: 'Vaccination',
-                    status: 'Scheduled'
-                },
-                {
-                    id: 4,
-                    date: yesterday.toISOString(),
-                    patient: 'Howard, Matthew',
-                    provider: 'Dr. Brown',
-                    reason: 'Illness',
-                    status: 'Completed'
-                },
-                {
-                    id: 5,
-                    date: yesterday.toISOString(),
-                    patient: 'Torres, Sophia',
-                    provider: 'Dr. Johnson',
-                    reason: 'Lab Results',
-                    status: 'Completed'
-                },
-                {
-                    id: 6,
-                    date: nextWeek.toISOString(),
-                    patient: 'Calderon, Stacey',
-                    provider: 'Dr. Brown',
-                    reason: 'Specialist Referral',
-                    status: 'Scheduled'
-                },
-                {
-                    id: 7,
-                    date: lastWeek.toISOString(),
-                    patient: 'Williams, Ian',
-                    provider: 'Dr. Smith',
-                    reason: 'Medication Refill',
-                    status: 'Canceled'
-                },
-                {
-                    id: 8,
-                    date: today.toISOString(),
-                    patient: 'Howard, Matthew',
-                    provider: 'Dr. Johnson',
-                    reason: 'Urgent Care',
-                    status: 'Scheduled'
-                },
-                {
-                    id: 9,
-                    date: tomorrow.toISOString(),
-                    patient: 'Torres, Sophia',
-                    provider: 'Dr. Smith',
-                    reason: 'Consultation',
-                    status: 'Scheduled'
-                },
-                {
-                    id: 10,
-                    date: lastWeek.toISOString(),
-                    patient: 'Castaneda, Michael',
-                    provider: 'Dr. Brown',
-                    reason: 'Follow-up',
-                    status: 'Completed'
-                }
-            ];
-        }
         
         function formatDate(dateObj) {
             return new Date(dateObj).toLocaleDateString('en-US', { 

--- a/appointments_api.py
+++ b/appointments_api.py
@@ -1,0 +1,225 @@
+import os
+import sys
+import psycopg2
+import datetime
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv('ehr-project/backend/.env')
+
+DB_CONFIG = {
+    'host': os.getenv('DB_HOST', 'localhost'),
+    'port': os.getenv('DB_PORT', '5432'),
+    'database': os.getenv('DB_NAME', 'ehr_db'),
+    'user': os.getenv('DB_USER', 'postgres'),
+    'password': os.getenv('DB_PASSWORD', 'postgres')
+}
+
+app = Flask(__name__)
+CORS(app)
+
+
+def get_db_connection():
+    """Create a database connection."""
+    try:
+        conn = psycopg2.connect(
+            host=DB_CONFIG['host'],
+            port=DB_CONFIG['port'],
+            database=DB_CONFIG['database'],
+            user=DB_CONFIG['user'],
+            password=DB_CONFIG['password']
+        )
+        return conn
+    except Exception as e:
+        print(f"Database connection error: {e}")
+        return None
+
+
+@app.route('/api/appointments', methods=['GET'])
+def get_appointments():
+    """Return a list of appointments."""
+    limit = int(request.args.get('limit', 50))
+    offset = int(request.args.get('offset', 0))
+
+    conn = get_db_connection()
+    if not conn:
+        return jsonify({'success': False, 'message': 'Database connection failed'}), 500
+
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT a.id, a.appointment_time, a.reason, a.status,
+                   COALESCE(p.last_name || ', ' || p.first_name, '') AS patient,
+                   COALESCE(u.full_name, u.username) AS provider
+            FROM appointments a
+            LEFT JOIN patients p ON a.patient_id = p.id
+            LEFT JOIN users u ON a.provider_id = u.id
+            ORDER BY a.appointment_time DESC
+            LIMIT %s OFFSET %s
+            """,
+            (limit, offset)
+        )
+        rows = cur.fetchall()
+        columns = [desc[0] for desc in cur.description]
+        appointments = []
+        for row in rows:
+            record = dict(zip(columns, row))
+            for k, v in record.items():
+                if isinstance(v, (datetime.date, datetime.datetime)):
+                    record[k] = v.isoformat()
+            appointments.append(record)
+        return jsonify({'success': True, 'appointments': appointments})
+    except Exception as e:
+        print(f"Error fetching appointments: {e}")
+        return jsonify({'success': False, 'message': str(e)}), 500
+    finally:
+        cur.close()
+        conn.close()
+
+
+@app.route('/api/appointments/<int:appt_id>', methods=['GET'])
+def get_appointment(appt_id):
+    """Return a specific appointment."""
+    conn = get_db_connection()
+    if not conn:
+        return jsonify({'success': False, 'message': 'Database connection failed'}), 500
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT a.id, a.appointment_time, a.reason, a.status,
+                   a.patient_id, a.provider_id,
+                   COALESCE(p.last_name || ', ' || p.first_name, '') AS patient,
+                   COALESCE(u.full_name, u.username) AS provider
+            FROM appointments a
+            LEFT JOIN patients p ON a.patient_id = p.id
+            LEFT JOIN users u ON a.provider_id = u.id
+            WHERE a.id = %s
+            """,
+            (appt_id,)
+        )
+        row = cur.fetchone()
+        if not row:
+            return jsonify({'success': False, 'message': 'Appointment not found'}), 404
+        columns = [desc[0] for desc in cur.description]
+        appt = dict(zip(columns, row))
+        for k, v in appt.items():
+            if isinstance(v, (datetime.date, datetime.datetime)):
+                appt[k] = v.isoformat()
+        return jsonify({'success': True, 'appointment': appt})
+    except Exception as e:
+        print(f"Error fetching appointment: {e}")
+        return jsonify({'success': False, 'message': str(e)}), 500
+    finally:
+        cur.close()
+        conn.close()
+
+
+@app.route('/api/appointments', methods=['POST'])
+def create_appointment():
+    """Create a new appointment."""
+    data = request.get_json()
+    if not data:
+        return jsonify({'success': False, 'message': 'No data provided'}), 400
+
+    conn = get_db_connection()
+    if not conn:
+        return jsonify({'success': False, 'message': 'Database connection failed'}), 500
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            INSERT INTO appointments (patient_id, provider_id, appointment_time, reason, status, created_at, updated_at)
+            VALUES (%s, %s, %s, %s, %s, NOW(), NOW())
+            RETURNING id
+            """,
+            (
+                data.get('patient_id'),
+                data.get('provider_id'),
+                data.get('appointment_time'),
+                data.get('reason'),
+                data.get('status', 'Scheduled')
+            )
+        )
+        new_id = cur.fetchone()[0]
+        conn.commit()
+        return jsonify({'success': True, 'appointment_id': new_id})
+    except Exception as e:
+        conn.rollback()
+        print(f"Error creating appointment: {e}")
+        return jsonify({'success': False, 'message': str(e)}), 500
+    finally:
+        cur.close()
+        conn.close()
+
+
+@app.route('/api/appointments/<int:appt_id>', methods=['PUT'])
+def update_appointment(appt_id):
+    """Update an appointment."""
+    data = request.get_json()
+    if not data:
+        return jsonify({'success': False, 'message': 'No data provided'}), 400
+
+    conn = get_db_connection()
+    if not conn:
+        return jsonify({'success': False, 'message': 'Database connection failed'}), 500
+    cur = conn.cursor()
+    try:
+        cur.execute("SELECT id FROM appointments WHERE id = %s", (appt_id,))
+        if not cur.fetchone():
+            return jsonify({'success': False, 'message': 'Appointment not found'}), 404
+
+        fields = []
+        params = []
+        allowed = ['patient_id', 'provider_id', 'appointment_time', 'reason', 'status']
+        for key in allowed:
+            if key in data:
+                fields.append(f"{key} = %s")
+                params.append(data[key])
+        fields.append("updated_at = NOW()")
+        params.append(appt_id)
+
+        cur.execute(
+            f"UPDATE appointments SET {', '.join(fields)} WHERE id = %s RETURNING id",
+            params
+        )
+        cur.fetchone()
+        conn.commit()
+        return jsonify({'success': True, 'message': 'Appointment updated'})
+    except Exception as e:
+        conn.rollback()
+        print(f"Error updating appointment: {e}")
+        return jsonify({'success': False, 'message': str(e)}), 500
+    finally:
+        cur.close()
+        conn.close()
+
+
+@app.route('/api/appointments/<int:appt_id>', methods=['DELETE'])
+def delete_appointment(appt_id):
+    """Delete an appointment."""
+    conn = get_db_connection()
+    if not conn:
+        return jsonify({'success': False, 'message': 'Database connection failed'}), 500
+    cur = conn.cursor()
+    try:
+        cur.execute("DELETE FROM appointments WHERE id = %s RETURNING id", (appt_id,))
+        row = cur.fetchone()
+        if not row:
+            return jsonify({'success': False, 'message': 'Appointment not found'}), 404
+        conn.commit()
+        return jsonify({'success': True, 'message': 'Appointment deleted'})
+    except Exception as e:
+        conn.rollback()
+        print(f"Error deleting appointment: {e}")
+        return jsonify({'success': False, 'message': str(e)}), 500
+    finally:
+        cur.close()
+        conn.close()
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8003, debug=True)

--- a/setup_db_tables.py
+++ b/setup_db_tables.py
@@ -139,6 +139,18 @@ def create_tables(conn):
             updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
         )
         """
+        """
+        CREATE TABLE IF NOT EXISTS appointments (
+            id SERIAL PRIMARY KEY,
+            patient_id INTEGER REFERENCES patients(id),
+            provider_id INTEGER REFERENCES users(id),
+            appointment_time TIMESTAMP NOT NULL,
+            reason TEXT,
+            status VARCHAR(20) NOT NULL DEFAULT 'Scheduled',
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """
     ]
     
     try:

--- a/start_servers.py
+++ b/start_servers.py
@@ -13,6 +13,7 @@ init()
 # Server ports
 API_PORT = 8001  # Login API
 PATIENT_API_PORT = 8002  # Patient API
+APPOINTMENTS_API_PORT = 8003  # Appointments API
 HTTP_PORT = 8080  # HTML/assets server
 
 # Track subprocess objects
@@ -116,6 +117,42 @@ def start_patient_api_server():
         print_error(f"Error starting patient API server: {e}")
         return False
 
+def start_appointments_api_server():
+    """Start the Appointments API server."""
+    print_header("Starting Appointments API Server")
+
+    try:
+        print_info(f"Starting appointments API server on port {APPOINTMENTS_API_PORT}...")
+
+        python_exe = sys.executable
+
+        api_process = subprocess.Popen(
+            [python_exe, "appointments_api.py"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        processes.append(api_process)
+
+        time.sleep(2)
+
+        if api_process.poll() is None:
+            print_success(f"Appointments API server running at http://localhost:{APPOINTMENTS_API_PORT}")
+            return True
+        else:
+            stdout, stderr = api_process.communicate()
+            print_error("Appointments API server failed to start:")
+            if stdout:
+                print_error(f"Output: {stdout}")
+            if stderr:
+                print_error(f"Error: {stderr}")
+            return False
+
+    except Exception as e:
+        print_error(f"Error starting appointments API server: {e}")
+        return False
+
 def start_http_server():
     """Start the HTTP file server."""
     print_header("Starting HTTP Server")
@@ -198,11 +235,14 @@ def main():
     
     # Start Patient API server
     patient_api_success = start_patient_api_server()
+
+    # Start Appointments API server
+    appointments_api_success = start_appointments_api_server()
     
     # Start HTTP server
     http_success = start_http_server()
     
-    if login_api_success and patient_api_success and http_success:
+    if login_api_success and patient_api_success and appointments_api_success and http_success:
         print_success("All servers started successfully!")
         
         # Open login page


### PR DESCRIPTION
## Summary
- create `appointments_api.py` providing CRUD endpoints
- extend database schema with an `appointments` table
- connect `appointments.html` to the new API and remove mock data
- launch appointments API from `start_servers.py`

## Testing
- `python -m py_compile appointments_api.py setup_db_tables.py start_servers.py`
- `pytest` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_684a40e36da48326a04b5c5b8a1bc03e