### PR TITLE
Add user dropdown menu for changing password

### DIFF
--- a/add_patient.html
+++ b/add_patient.html
@@ -58,10 +58,38 @@
             display: flex;
             align-items: center;
             gap: 15px;
+            position: relative;
         }
         
         .user-info span {
             font-weight: 500;
+            cursor: pointer;
+        }
+
+        .user-dropdown {
+            position: absolute;
+            top: calc(100% + 5px);
+            right: 0;
+            background-color: var(--secondary-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            display: none;
+            flex-direction: column;
+            min-width: 150px;
+            z-index: 100;
+        }
+
+        .user-dropdown button {
+            background: none;
+            border: none;
+            color: var(--text-color);
+            padding: 8px 15px;
+            text-align: left;
+            cursor: pointer;
+        }
+
+        .user-dropdown button:hover {
+            background-color: rgba(77, 139, 240, 0.1);
         }
         
         .btn {
@@ -244,8 +272,17 @@
             <h1>Top EHR System</h1>
         </div>
         <div class="user-info">
-            <span id="username">Loading...</span>
-            <button class="btn" id="logoutBtn">Logout</button>
+            <span id="username" class="username">Loading...</span>
+            <div class="user-dropdown" id="userDropdown">
+                <button id="openChangePassword">Change Password</button>
+                <button id="logoutBtn">Logout</button>
+            </div>
+        </div>
+        <div id="changePasswordContainer" style="display:none;">
+            <input type="password" id="oldPassword" placeholder="Current password">
+            <input type="password" id="newPassword" placeholder="New password">
+            <button class="btn" id="changePasswordBtn">Update Password</button>
+            <div id="changePasswordStatus"></div>
         </div>
     </header>
     
@@ -424,6 +461,54 @@
 
             const username = localStorage.getItem('ehrUsername');
             document.getElementById('username').textContent = username || 'User';
+
+            const usernameEl = document.getElementById('username');
+            const dropdown = document.getElementById('userDropdown');
+            const formContainer = document.getElementById('changePasswordContainer');
+
+            usernameEl.addEventListener('click', function() {
+                dropdown.style.display = dropdown.style.display === 'block' ? 'none' : 'block';
+            });
+
+            document.addEventListener('click', function(e) {
+                if (!document.querySelector('.user-info').contains(e.target)) {
+                    dropdown.style.display = 'none';
+                }
+            });
+
+            document.getElementById('openChangePassword').addEventListener('click', function() {
+                dropdown.style.display = 'none';
+                formContainer.style.display = formContainer.style.display === 'flex' ? 'none' : 'flex';
+            });
+
+            // Handle password update
+            document.getElementById('changePasswordBtn').addEventListener('click', function() {
+                const oldPass = document.getElementById('oldPassword').value;
+                const newPass = document.getElementById('newPassword').value;
+                const statusDiv = document.getElementById('changePasswordStatus');
+
+                fetch('http://localhost:8001/api/change-password', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ username, old_password: oldPass, new_password: newPass })
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success) {
+                        statusDiv.textContent = 'Password updated successfully.';
+                        statusDiv.style.color = '#4caf50';
+                        document.getElementById('oldPassword').value = '';
+                        document.getElementById('newPassword').value = '';
+                    } else {
+                        statusDiv.textContent = data.message;
+                        statusDiv.style.color = '#f44336';
+                    }
+                })
+                .catch(err => {
+                    statusDiv.textContent = 'Error updating password';
+                    statusDiv.style.color = '#f44336';
+                });
+            });
 
             document.getElementById('logoutBtn').addEventListener('click', function() {
                 localStorage.removeItem('ehrToken');

--- a/appointments.html
+++ b/appointments.html
@@ -58,10 +58,38 @@
             display: flex;
             align-items: center;
             gap: 15px;
+            position: relative;
         }
         
         .user-info span {
             font-weight: 500;
+            cursor: pointer;
+        }
+
+        .user-dropdown {
+            position: absolute;
+            top: calc(100% + 5px);
+            right: 0;
+            background-color: var(--secondary-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            display: none;
+            flex-direction: column;
+            min-width: 150px;
+            z-index: 100;
+        }
+
+        .user-dropdown button {
+            background: none;
+            border: none;
+            color: var(--text-color);
+            padding: 8px 15px;
+            text-align: left;
+            cursor: pointer;
+        }
+
+        .user-dropdown button:hover {
+            background-color: rgba(77, 139, 240, 0.1);
         }
         
         .btn {
@@ -273,8 +301,17 @@
             <h1>Top EHR System</h1>
         </div>
         <div class="user-info">
-            <span id="username">Loading...</span>
-            <button class="btn" id="logoutBtn">Logout</button>
+            <span id="username" class="username">Loading...</span>
+            <div class="user-dropdown" id="userDropdown">
+                <button id="openChangePassword">Change Password</button>
+                <button id="logoutBtn">Logout</button>
+            </div>
+        </div>
+        <div id="changePasswordContainer" style="display:none;">
+            <input type="password" id="oldPassword" placeholder="Current password">
+            <input type="password" id="newPassword" placeholder="New password">
+            <button class="btn" id="changePasswordBtn">Update Password</button>
+            <div id="changePasswordStatus"></div>
         </div>
     </header>
     
@@ -344,6 +381,54 @@
             const username = localStorage.getItem('ehrUsername');
             document.getElementById('username').textContent = username || 'User';
             
+            const usernameEl = document.getElementById('username');
+            const dropdown = document.getElementById('userDropdown');
+            const formContainer = document.getElementById('changePasswordContainer');
+
+            usernameEl.addEventListener('click', function() {
+                dropdown.style.display = dropdown.style.display === 'block' ? 'none' : 'block';
+            });
+
+            document.addEventListener('click', function(e) {
+                if (!document.querySelector('.user-info').contains(e.target)) {
+                    dropdown.style.display = 'none';
+                }
+            });
+
+            document.getElementById('openChangePassword').addEventListener('click', function() {
+                dropdown.style.display = 'none';
+                formContainer.style.display = formContainer.style.display === 'flex' ? 'none' : 'flex';
+            });
+
+            // Handle password update
+            document.getElementById('changePasswordBtn').addEventListener('click', function() {
+                const oldPass = document.getElementById('oldPassword').value;
+                const newPass = document.getElementById('newPassword').value;
+                const statusDiv = document.getElementById('changePasswordStatus');
+
+                fetch('http://localhost:8001/api/change-password', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ username, old_password: oldPass, new_password: newPass })
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success) {
+                        statusDiv.textContent = 'Password updated successfully.';
+                        statusDiv.style.color = '#4caf50';
+                        document.getElementById('oldPassword').value = '';
+                        document.getElementById('newPassword').value = '';
+                    } else {
+                        statusDiv.textContent = data.message;
+                        statusDiv.style.color = '#f44336';
+                    }
+                })
+                .catch(err => {
+                    statusDiv.textContent = 'Error updating password';
+                    statusDiv.style.color = '#f44336';
+                });
+            });
+
             // Logout function
             document.getElementById('logoutBtn').addEventListener('click', function() {
                 localStorage.removeItem('ehrToken');

--- a/dashboard.html
+++ b/dashboard.html
@@ -58,6 +58,7 @@
             display: flex;
             align-items: center;
             gap: 15px;
+            position: relative;
         }
 
         #changePasswordContainer {
@@ -82,6 +83,33 @@
         
         .user-info span {
             font-weight: 500;
+            cursor: pointer;
+        }
+
+        .user-dropdown {
+            position: absolute;
+            top: calc(100% + 5px);
+            right: 0;
+            background-color: var(--secondary-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            display: none;
+            flex-direction: column;
+            min-width: 150px;
+            z-index: 100;
+        }
+
+        .user-dropdown button {
+            background: none;
+            border: none;
+            color: var(--text-color);
+            padding: 8px 15px;
+            text-align: left;
+            cursor: pointer;
+        }
+
+        .user-dropdown button:hover {
+            background-color: rgba(77, 139, 240, 0.1);
         }
         
         .btn {
@@ -330,8 +358,11 @@
             <h1>Top EHR System</h1>
         </div>
         <div class="user-info">
-            <span id="username">Loading...</span>
-            <button class="btn" id="logoutBtn">Logout</button>
+            <span id="username" class="username">Loading...</span>
+            <div class="user-dropdown" id="userDropdown">
+                <button id="openChangePassword">Change Password</button>
+                <button id="logoutBtn">Logout</button>
+            </div>
         </div>
         <div id="changePasswordContainer">
             <input type="password" id="oldPassword" placeholder="Current password">
@@ -339,7 +370,6 @@
             <button class="btn" id="changePasswordBtn">Update Password</button>
             <div id="changePasswordStatus"></div>
         </div>
-        <button class="btn" id="toggleChangePassword" style="margin-top:10px;">Change Password</button>
     </header>
     
     <div class="container">
@@ -445,10 +475,23 @@
             const username = localStorage.getItem('ehrUsername');
             document.getElementById('username').textContent = username || 'User';
 
-            // Toggle change password form
-            const toggleBtn = document.getElementById('toggleChangePassword');
+            // Dropdown menu logic
+            const usernameEl = document.getElementById('username');
+            const dropdown = document.getElementById('userDropdown');
             const formContainer = document.getElementById('changePasswordContainer');
-            toggleBtn.addEventListener('click', function() {
+
+            usernameEl.addEventListener('click', function(e) {
+                dropdown.style.display = dropdown.style.display === 'block' ? 'none' : 'block';
+            });
+
+            document.addEventListener('click', function(e) {
+                if (!document.querySelector('.user-info').contains(e.target)) {
+                    dropdown.style.display = 'none';
+                }
+            });
+
+            document.getElementById('openChangePassword').addEventListener('click', function() {
+                dropdown.style.display = 'none';
                 formContainer.style.display = formContainer.style.display === 'flex' ? 'none' : 'flex';
             });
 

--- a/edit_patient.html
+++ b/edit_patient.html
@@ -58,10 +58,38 @@
             display: flex;
             align-items: center;
             gap: 15px;
+            position: relative;
         }
         
         .user-info span {
             font-weight: 500;
+            cursor: pointer;
+        }
+
+        .user-dropdown {
+            position: absolute;
+            top: calc(100% + 5px);
+            right: 0;
+            background-color: var(--secondary-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            display: none;
+            flex-direction: column;
+            min-width: 150px;
+            z-index: 100;
+        }
+
+        .user-dropdown button {
+            background: none;
+            border: none;
+            color: var(--text-color);
+            padding: 8px 15px;
+            text-align: left;
+            cursor: pointer;
+        }
+
+        .user-dropdown button:hover {
+            background-color: rgba(77, 139, 240, 0.1);
         }
         
         .btn {
@@ -244,8 +272,17 @@
             <h1>Top EHR System</h1>
         </div>
         <div class="user-info">
-            <span id="username">Loading...</span>
-            <button class="btn" id="logoutBtn">Logout</button>
+            <span id="username" class="username">Loading...</span>
+            <div class="user-dropdown" id="userDropdown">
+                <button id="openChangePassword">Change Password</button>
+                <button id="logoutBtn">Logout</button>
+            </div>
+        </div>
+        <div id="changePasswordContainer" style="display:none;">
+            <input type="password" id="oldPassword" placeholder="Current password">
+            <input type="password" id="newPassword" placeholder="New password">
+            <button class="btn" id="changePasswordBtn">Update Password</button>
+            <div id="changePasswordStatus"></div>
         </div>
     </header>
     
@@ -434,6 +471,54 @@
             const username = localStorage.getItem('ehrUsername');
             document.getElementById('username').textContent = username || 'User';
             
+            const usernameEl = document.getElementById('username');
+            const dropdown = document.getElementById('userDropdown');
+            const formContainer = document.getElementById('changePasswordContainer');
+
+            usernameEl.addEventListener('click', function() {
+                dropdown.style.display = dropdown.style.display === 'block' ? 'none' : 'block';
+            });
+
+            document.addEventListener('click', function(e) {
+                if (!document.querySelector('.user-info').contains(e.target)) {
+                    dropdown.style.display = 'none';
+                }
+            });
+
+            document.getElementById('openChangePassword').addEventListener('click', function() {
+                dropdown.style.display = 'none';
+                formContainer.style.display = formContainer.style.display === 'flex' ? 'none' : 'flex';
+            });
+
+            // Handle password update
+            document.getElementById('changePasswordBtn').addEventListener('click', function() {
+                const oldPass = document.getElementById('oldPassword').value;
+                const newPass = document.getElementById('newPassword').value;
+                const statusDiv = document.getElementById('changePasswordStatus');
+
+                fetch('http://localhost:8001/api/change-password', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ username, old_password: oldPass, new_password: newPass })
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success) {
+                        statusDiv.textContent = 'Password updated successfully.';
+                        statusDiv.style.color = '#4caf50';
+                        document.getElementById('oldPassword').value = '';
+                        document.getElementById('newPassword').value = '';
+                    } else {
+                        statusDiv.textContent = data.message;
+                        statusDiv.style.color = '#f44336';
+                    }
+                })
+                .catch(err => {
+                    statusDiv.textContent = 'Error updating password';
+                    statusDiv.style.color = '#f44336';
+                });
+            });
+
             // Logout function
             document.getElementById('logoutBtn').addEventListener('click', function() {
                 localStorage.removeItem('ehrToken');

--- a/patients_list.html
+++ b/patients_list.html
@@ -58,10 +58,38 @@
             display: flex;
             align-items: center;
             gap: 15px;
+            position: relative;
         }
         
         .user-info span {
             font-weight: 500;
+            cursor: pointer;
+        }
+
+        .user-dropdown {
+            position: absolute;
+            top: calc(100% + 5px);
+            right: 0;
+            background-color: var(--secondary-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            display: none;
+            flex-direction: column;
+            min-width: 150px;
+            z-index: 100;
+        }
+
+        .user-dropdown button {
+            background: none;
+            border: none;
+            color: var(--text-color);
+            padding: 8px 15px;
+            text-align: left;
+            cursor: pointer;
+        }
+
+        .user-dropdown button:hover {
+            background-color: rgba(77, 139, 240, 0.1);
         }
         
         .btn {
@@ -260,8 +288,17 @@
             <h1>Top EHR System</h1>
         </div>
         <div class="user-info">
-            <span id="username">Loading...</span>
-            <button class="btn" id="logoutBtn">Logout</button>
+            <span id="username" class="username">Loading...</span>
+            <div class="user-dropdown" id="userDropdown">
+                <button id="openChangePassword">Change Password</button>
+                <button id="logoutBtn">Logout</button>
+            </div>
+        </div>
+        <div id="changePasswordContainer" style="display:none;">
+            <input type="password" id="oldPassword" placeholder="Current password">
+            <input type="password" id="newPassword" placeholder="New password">
+            <button class="btn" id="changePasswordBtn">Update Password</button>
+            <div id="changePasswordStatus"></div>
         </div>
     </header>
     
@@ -332,6 +369,54 @@
             const username = localStorage.getItem('ehrUsername');
             document.getElementById('username').textContent = username || 'User';
             
+            const usernameEl = document.getElementById('username');
+            const dropdown = document.getElementById('userDropdown');
+            const formContainer = document.getElementById('changePasswordContainer');
+
+            usernameEl.addEventListener('click', function() {
+                dropdown.style.display = dropdown.style.display === 'block' ? 'none' : 'block';
+            });
+
+            document.addEventListener('click', function(e) {
+                if (!document.querySelector('.user-info').contains(e.target)) {
+                    dropdown.style.display = 'none';
+                }
+            });
+
+            document.getElementById('openChangePassword').addEventListener('click', function() {
+                dropdown.style.display = 'none';
+                formContainer.style.display = formContainer.style.display === 'flex' ? 'none' : 'flex';
+            });
+
+            // Handle password update
+            document.getElementById('changePasswordBtn').addEventListener('click', function() {
+                const oldPass = document.getElementById('oldPassword').value;
+                const newPass = document.getElementById('newPassword').value;
+                const statusDiv = document.getElementById('changePasswordStatus');
+
+                fetch('http://localhost:8001/api/change-password', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ username, old_password: oldPass, new_password: newPass })
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success) {
+                        statusDiv.textContent = 'Password updated successfully.';
+                        statusDiv.style.color = '#4caf50';
+                        document.getElementById('oldPassword').value = '';
+                        document.getElementById('newPassword').value = '';
+                    } else {
+                        statusDiv.textContent = data.message;
+                        statusDiv.style.color = '#f44336';
+                    }
+                })
+                .catch(err => {
+                    statusDiv.textContent = 'Error updating password';
+                    statusDiv.style.color = '#f44336';
+                });
+            });
+
             // Logout function
             document.getElementById('logoutBtn').addEventListener('click', function() {
                 localStorage.removeItem('ehrToken');

--- a/records.html
+++ b/records.html
@@ -58,10 +58,38 @@
             display: flex;
             align-items: center;
             gap: 15px;
+            position: relative;
         }
         
         .user-info span {
             font-weight: 500;
+            cursor: pointer;
+        }
+
+        .user-dropdown {
+            position: absolute;
+            top: calc(100% + 5px);
+            right: 0;
+            background-color: var(--secondary-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            display: none;
+            flex-direction: column;
+            min-width: 150px;
+            z-index: 100;
+        }
+
+        .user-dropdown button {
+            background: none;
+            border: none;
+            color: var(--text-color);
+            padding: 8px 15px;
+            text-align: left;
+            cursor: pointer;
+        }
+
+        .user-dropdown button:hover {
+            background-color: rgba(77, 139, 240, 0.1);
         }
         
         .btn {
@@ -282,8 +310,17 @@
             <h1>Top EHR System</h1>
         </div>
         <div class="user-info">
-            <span id="username">Loading...</span>
-            <button class="btn" id="logoutBtn">Logout</button>
+            <span id="username" class="username">Loading...</span>
+            <div class="user-dropdown" id="userDropdown">
+                <button id="openChangePassword">Change Password</button>
+                <button id="logoutBtn">Logout</button>
+            </div>
+        </div>
+        <div id="changePasswordContainer" style="display:none;">
+            <input type="password" id="oldPassword" placeholder="Current password">
+            <input type="password" id="newPassword" placeholder="New password">
+            <button class="btn" id="changePasswordBtn">Update Password</button>
+            <div id="changePasswordStatus"></div>
         </div>
     </header>
     
@@ -353,6 +390,54 @@
             const username = localStorage.getItem('ehrUsername');
             document.getElementById('username').textContent = username || 'User';
             
+            const usernameEl = document.getElementById('username');
+            const dropdown = document.getElementById('userDropdown');
+            const formContainer = document.getElementById('changePasswordContainer');
+
+            usernameEl.addEventListener('click', function() {
+                dropdown.style.display = dropdown.style.display === 'block' ? 'none' : 'block';
+            });
+
+            document.addEventListener('click', function(e) {
+                if (!document.querySelector('.user-info').contains(e.target)) {
+                    dropdown.style.display = 'none';
+                }
+            });
+
+            document.getElementById('openChangePassword').addEventListener('click', function() {
+                dropdown.style.display = 'none';
+                formContainer.style.display = formContainer.style.display === 'flex' ? 'none' : 'flex';
+            });
+
+            // Handle password update
+            document.getElementById('changePasswordBtn').addEventListener('click', function() {
+                const oldPass = document.getElementById('oldPassword').value;
+                const newPass = document.getElementById('newPassword').value;
+                const statusDiv = document.getElementById('changePasswordStatus');
+
+                fetch('http://localhost:8001/api/change-password', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ username, old_password: oldPass, new_password: newPass })
+                })
+                .then(res => res.json())
+                .then(data => {
+                    if (data.success) {
+                        statusDiv.textContent = 'Password updated successfully.';
+                        statusDiv.style.color = '#4caf50';
+                        document.getElementById('oldPassword').value = '';
+                        document.getElementById('newPassword').value = '';
+                    } else {
+                        statusDiv.textContent = data.message;
+                        statusDiv.style.color = '#f44336';
+                    }
+                })
+                .catch(err => {
+                    statusDiv.textContent = 'Error updating password';
+                    statusDiv.style.color = '#f44336';
+                });
+            });
+
             // Logout function
             document.getElementById('logoutBtn').addEventListener('click', function() {
                 localStorage.removeItem('ehrToken');


### PR DESCRIPTION
## Summary
- create a dropdown menu next to the username in all authenticated pages
- allow toggling the change password form from the dropdown
- hide or show the dropdown when clicking username

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684ad55286bc8326a588f95b9b861edb