### PR TITLE
Add password field labels

### DIFF
--- a/add_patient.html
+++ b/add_patient.html
@@ -279,7 +279,9 @@
             </div>
         </div>
         <div id="changePasswordContainer" style="display:none;">
+            <label for="oldPassword">Enter your current password to confirm changes</label>
             <input type="password" id="oldPassword" placeholder="Current password">
+            <label for="newPassword">Enter your new password</label>
             <input type="password" id="newPassword" placeholder="New password">
             <button class="btn" id="changePasswordBtn">Update Password</button>
             <div id="changePasswordStatus"></div>

--- a/appointments.html
+++ b/appointments.html
@@ -308,7 +308,9 @@
             </div>
         </div>
         <div id="changePasswordContainer" style="display:none;">
+            <label for="oldPassword">Enter your current password to confirm changes</label>
             <input type="password" id="oldPassword" placeholder="Current password">
+            <label for="newPassword">Enter your new password</label>
             <input type="password" id="newPassword" placeholder="New password">
             <button class="btn" id="changePasswordBtn">Update Password</button>
             <div id="changePasswordStatus"></div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -365,7 +365,9 @@
             </div>
         </div>
         <div id="changePasswordContainer">
+            <label for="oldPassword">Enter your current password to confirm changes</label>
             <input type="password" id="oldPassword" placeholder="Current password">
+            <label for="newPassword">Enter your new password</label>
             <input type="password" id="newPassword" placeholder="New password">
             <button class="btn" id="changePasswordBtn">Update Password</button>
             <div id="changePasswordStatus"></div>

--- a/edit_patient.html
+++ b/edit_patient.html
@@ -279,7 +279,9 @@
             </div>
         </div>
         <div id="changePasswordContainer" style="display:none;">
+            <label for="oldPassword">Enter your current password to confirm changes</label>
             <input type="password" id="oldPassword" placeholder="Current password">
+            <label for="newPassword">Enter your new password</label>
             <input type="password" id="newPassword" placeholder="New password">
             <button class="btn" id="changePasswordBtn">Update Password</button>
             <div id="changePasswordStatus"></div>

--- a/patients_list.html
+++ b/patients_list.html
@@ -295,7 +295,9 @@
             </div>
         </div>
         <div id="changePasswordContainer" style="display:none;">
+            <label for="oldPassword">Enter your current password to confirm changes</label>
             <input type="password" id="oldPassword" placeholder="Current password">
+            <label for="newPassword">Enter your new password</label>
             <input type="password" id="newPassword" placeholder="New password">
             <button class="btn" id="changePasswordBtn">Update Password</button>
             <div id="changePasswordStatus"></div>

--- a/records.html
+++ b/records.html
@@ -317,7 +317,9 @@
             </div>
         </div>
         <div id="changePasswordContainer" style="display:none;">
+            <label for="oldPassword">Enter your current password to confirm changes</label>
             <input type="password" id="oldPassword" placeholder="Current password">
+            <label for="newPassword">Enter your new password</label>
             <input type="password" id="newPassword" placeholder="New password">
             <button class="btn" id="changePasswordBtn">Update Password</button>
             <div id="changePasswordStatus"></div>


### PR DESCRIPTION
## Summary
- show explicit label for current password confirmation
- prompt users for new password in change password forms

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ad82ecd848326b048b70b0d1ff587