### PR TITLE
Add admin user creation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A web-based Electronic Health Record system designed for military healthcare pro
 - **Dashboard**: Overview of key statistics (total patients, active patients, today's appointments, pending records)
 - **Detail Views**: Specialized pages for patients, appointments, and medical records
 - **Responsive Design**: Dark-themed UI optimized for healthcare environments
+- **Admin User Management**: Admins can add new users via `/admin/create_user`
+- **Secure Password Hashing**: New accounts use bcrypt while legacy SHA-256 hashes are still supported
 
 ## System Architecture
 
@@ -82,6 +84,10 @@ Alternatively, run `python start_servers.py` to launch the HTTP, authentication,
 2. Alternatively, use the Vue-based login at `http://localhost:8080/login_vue.html`
 3. Login with provided credentials
 4. Navigate through the dashboard to access patients, appointments, and records
+
+### Admin User Creation
+
+Logged-in admins can add new users. Use the **Create User** button on the dashboard or open `http://localhost:8001/admin/create_user` with your session token. Submit a username, email, password and role. Passwords are stored using bcrypt hashing.
 
 ## Testing
 

--- a/create_user.html
+++ b/create_user.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Create User</title>
+    <style>
+        :root {
+            --primary-bg: #121212;
+            --secondary-bg: #1e1e1e;
+            --accent-color: #4d8bf0;
+            --text-color: #e0e0e0;
+            --border-color: #333;
+            --hover-color: #2d5ca8;
+            --success-color: #4caf50;
+            --danger-color: #f44336;
+        }
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: var(--primary-bg);
+            color: var(--text-color);
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 500px;
+            margin: 40px auto;
+            background-color: var(--secondary-bg);
+            padding: 20px;
+            border-radius: 8px;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+        }
+        input, select {
+            width: 100%;
+            padding: 10px;
+            margin-bottom: 15px;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            background-color: var(--primary-bg);
+            color: var(--text-color);
+        }
+        button {
+            background-color: var(--accent-color);
+            color: white;
+            padding: 10px 15px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: var(--hover-color);
+        }
+        .status {
+            margin-top: 10px;
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2>Create User</h2>
+        <form id="createUserForm">
+            <label for="username">Username</label>
+            <input type="text" id="username" required>
+            <label for="email">Email</label>
+            <input type="email" id="email" required>
+            <label for="password">Password</label>
+            <input type="password" id="password" required>
+            <label for="role">Role</label>
+            <select id="role">
+                <option value="admin">admin</option>
+                <option value="doctor">doctor</option>
+                <option value="patient">patient</option>
+            </select>
+            <button type="submit">Create User</button>
+        </form>
+        <div class="status" id="status"></div>
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const form = document.getElementById('createUserForm');
+            const statusDiv = document.getElementById('status');
+            const token = localStorage.getItem('ehrToken');
+            if (!token) {
+                window.location.href = 'login.html';
+                return;
+            }
+            form.addEventListener('submit', e => {
+                e.preventDefault();
+                const data = {
+                    username: document.getElementById('username').value,
+                    email: document.getElementById('email').value,
+                    password: document.getElementById('password').value,
+                    role: document.getElementById('role').value
+                };
+                fetch('http://localhost:8001/admin/create_user', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': token
+                    },
+                    body: JSON.stringify(data)
+                })
+                .then(r => r.json())
+                .then(resp => {
+                    statusDiv.style.display = 'block';
+                    if (resp.success) {
+                        statusDiv.style.color = 'var(--success-color)';
+                        statusDiv.textContent = 'User created successfully';
+                        setTimeout(() => {
+                            window.location.href = 'dashboard.html';
+                        }, 1000);
+                    } else {
+                        statusDiv.style.color = 'var(--danger-color)';
+                        statusDiv.textContent = resp.message || 'Error creating user';
+                    }
+                })
+                .catch(err => {
+                    statusDiv.style.display = 'block';
+                    statusDiv.style.color = 'var(--danger-color)';
+                    statusDiv.textContent = err.toString();
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -422,6 +422,7 @@
                         Recent Patients
                         <div>
                             <button class="btn" id="addPatientBtn">Add Patient</button>
+                            <button class="btn" id="createUserBtn">Create User</button>
                             <button class="btn" id="refreshBtn">Refresh</button>
                         </div>
                     </h3>
@@ -544,6 +545,15 @@
             // Navigate to add patient page
             document.getElementById('addPatientBtn').addEventListener('click', function() {
                 window.location.href = 'add_patient.html';
+            });
+
+            document.getElementById('createUserBtn').addEventListener('click', function() {
+                const token = localStorage.getItem('ehrToken');
+                if (!token) {
+                    window.location.href = 'login.html';
+                    return;
+                }
+                window.location.href = 'http://localhost:8001/admin/create_user?token=' + encodeURIComponent(token);
             });
             
             // Set up search button


### PR DESCRIPTION
## Summary
- implement secure password hashing support
- add `/admin/create_user` endpoint for admins
- create new `create_user.html` form
- link to new page from dashboard

## Testing
- `python -m py_compile login_api.py`
- `python -m py_compile appointments_api.py patient_api.py setup_db_tables.py create_test_user.py start_servers.py check_db_schema.py generate_realistic_data.py login_api.py`


------
https://chatgpt.com/codex/tasks/task_e_684dd803410c832690882788f6b762c5